### PR TITLE
Support unicode slugs in newsitem auto-redirecting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,10 @@ python:
   - 3.5
 
 env:
+  - TOXENV=dj19-wt18
+  - TOXENV=dj19-wt19
   - TOXENV=dj110-wt18
   - TOXENV=dj110-wt19
-  - TOXENV=dj111-wt18
-  - TOXENV=dj111-wt19
 
 # Matrix of build options
 matrix:

--- a/tests/test_editing.py
+++ b/tests/test_editing.py
@@ -10,6 +10,7 @@ from wagtailnews.views.editor import OPEN_PREVIEW_PARAM
 class TestCreateNewsItem(TestCase, WagtailTestUtils):
 
     def setUp(self):
+        super(TestCreateNewsItem, self).setUp()
         self.login()
         root_page = Page.objects.get(pk=2)
         self.index = NewsIndex(
@@ -79,6 +80,7 @@ class TestCreateNewsItem(TestCase, WagtailTestUtils):
 class TestEditNewsItem(TestCase, WagtailTestUtils):
 
     def setUp(self):
+        super(TestEditNewsItem, self).setUp()
         self.login()
         root_page = Page.objects.get(pk=2)
         self.index = NewsIndex(
@@ -161,6 +163,7 @@ class TestEditNewsItem(TestCase, WagtailTestUtils):
 
 class TestPreviewDraft(TestCase, WagtailTestUtils):
     def setUp(self):
+        super(TestPreviewDraft, self).setUp()
         self.user = self.login()
         root_page = Page.objects.get(pk=2)
         self.index = root_page.add_child(instance=NewsIndex(

--- a/tests/test_feed.py
+++ b/tests/test_feed.py
@@ -14,6 +14,7 @@ class TestFeed(TestCase, WagtailTestUtils):
     """
 
     def setUp(self):
+        super(TestFeed, self).setUp()
         site = Site.objects.get(is_default_site=True)
         self.root_page = site.root_page
         self.index = self.root_page.add_child(instance=NewsIndex(
@@ -76,6 +77,7 @@ class TestCustomFeed(TestCase, WagtailTestUtils):
     Test custom Feed classes on the NewsIndex are used
     """
     def setUp(self):
+        super(TestCustomFeed, self).setUp()
         site = Site.objects.get(is_default_site=True)
         root_page = site.root_page
         self.index = NewsIndex(

--- a/tests/test_newsindex.py
+++ b/tests/test_newsindex.py
@@ -12,7 +12,7 @@ from tests.app.models import (
 
 class TestNewsIndex(TestCase, WagtailTestUtils):
     def setUp(self):
-        super(TestNewsIndex, self).setUpClass()
+        super(TestNewsIndex, self).setUp()
         self.root = Page.objects.get(pk=2)
         self.rf = RequestFactory()
 

--- a/tests/test_newsitem.py
+++ b/tests/test_newsitem.py
@@ -13,6 +13,7 @@ from tests.app.models import NewsIndex, NewsItem
 class TestNewsItem(TestCase, WagtailTestUtils):
 
     def setUp(self):
+        super(TestNewsItem, self).setUp()
         site = Site.objects.get(is_default_site=True)
         root_page = site.root_page
         self.index = NewsIndex(

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -10,6 +10,7 @@ from tests.app.models import NewsIndex, NewsItem
 class TestNewsItemWithTags(TestCase, WagtailTestUtils):
 
     def setUp(self):
+        super(TestNewsItemWithTags, self).setUp()
         root_page = Page.objects.get(pk=2)
         self.index = NewsIndex(
             title='News', slug='news')

--- a/tests/test_urls.py
+++ b/tests/test_urls.py
@@ -20,6 +20,7 @@ def noop(x):
 class TestNewsList(TestCase, WagtailTestUtils):
 
     def setUp(self):
+        super(TestNewsList, self).setUp()
         site = Site.objects.get(is_default_site=True)
         root_page = site.root_page
         self.index = NewsIndex(
@@ -120,6 +121,7 @@ class TestNewsList(TestCase, WagtailTestUtils):
 class TestMultipleSites(TestCase, WagtailTestUtils):
 
     def setUp(self):
+        super(TestMultipleSites, self).setUp()
         root = Page.objects.get(pk=1)
         root_a = Page(
             title='Home A', slug='home-a')

--- a/tests/test_urls.py
+++ b/tests/test_urls.py
@@ -1,5 +1,6 @@
 import datetime
 
+from django.core.cache import cache
 from django.test import TestCase
 from django.utils import timezone
 from wagtail.tests.utils import WagtailTestUtils
@@ -146,6 +147,13 @@ class TestMultipleSites(TestCase, WagtailTestUtils):
             newsindex=self.index_a, title='Post A', date=dt(2015, 8, 1))
         self.item_b = NewsItem.objects.create(
             newsindex=self.index_b, title='Post B', date=dt(2015, 8, 2))
+
+    @classmethod
+    def tearDownClass(cls):
+        super(TestMultipleSites, cls).tearDownClass()
+        # Clear site cache when the tests finish to prevent other tests being
+        # polluted by a stale cache.
+        cache.delete('wagtail_site_root_paths')
 
     def test_index(self):
         response = self.client.get(self.index_a.url,

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 skip_missing_interpreters = True
 
 envlist =
-	py{27,34,35}-dj{110,111}-wt{18,19}
+	py{27,34,35}-dj{19,110}-wt{18,19}
 	isort,flake8,docs
 
 


### PR DESCRIPTION
Previously it was comparing the percent-encoded and non-percent-encoded versions of the urls, saw they didnt match, and redirected, only to compare the different strings again the next time around, and redirect again, and again, and again, etc.