### PR TITLE
Make NewsItem.url a property

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,10 @@ python:
   - 3.5
 
 env:
-  - TOXENV=dj19-wt18
-  - TOXENV=dj19-wt19
-  - TOXENV=dj110-wt18
   - TOXENV=dj110-wt19
+  - TOXENV=dj110-wt110
+  - TOXENV=dj111-wt19
+  - TOXENV=dj111-wt110
 
 # Matrix of build options
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: python
 cache: pip
 
 python:
-  - 2.7
   - 3.4
   - 3.5
 

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -47,10 +47,18 @@ Attributes
     The template to use for this news item.
     Defaults to ``app_label/model_name.html``.
 
+.. attribute:: AbstractNewsItem.url
+
+    The URL of this news item, using the news indexes :attr:`~wagtail.wagtailcore.models.Page.url` attribute.
+
+.. attribute:: AbstractNewsItem.full_url
+
+    The full URL of this news item, using the news indexes :attr:`~wagtail.wagtailcore.models.Page.full_url` attribute.
+
 Methods
 -------
 
-.. automethod:: AbstractNewsItem.get_nice_url
+.. automethod:: AbstractNewsItem.get_slug
 
     Make a slug to put in the URL.
     News items are fetched using their ID, which is also embedded in the URL,
@@ -80,14 +88,6 @@ Methods
         '2016/08/11/1234-my-news-item/'
 
     See also :meth:`AbstractNewsItem.get_nice_url`.
-
-.. automethod:: AbstractNewsItem.url
-
-    Return the URL of this news item, using the news indexes :attr:`~wagtail.wagtailcore.models.Page.url` attribute.
-
-.. automethod:: AbstractNewsItem.full_url
-
-    Return the URL of this news item, using the news indexes :attr:`~wagtail.wagtailcore.models.Page.full_url` attribute.
 
 News index
 ==========

--- a/runtests.py
+++ b/runtests.py
@@ -2,12 +2,15 @@
 
 import os
 import sys
+import warnings
 
 
 def run():
     from django.core.management import execute_from_command_line
     os.environ['DJANGO_SETTINGS_MODULE'] = 'tests.app.settings'
     os.environ.setdefault('DATABASE_NAME', ':memory:')
+    warnings.filterwarnings('always', module='wagtailnews', category=DeprecationWarning)
+    warnings.filterwarnings('always', module='wagtailnews', category=PendingDeprecationWarning)
     execute_from_command_line([sys.argv[0], 'test'] + sys.argv[1:])
 
 

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,6 @@ setup(
 
     install_requires=[
         'wagtail>=1.5',
-        'enum34~=1.1.6;python_version<"3.4"',
     ],
     extras_require={
         'docs': documentation_extras
@@ -49,6 +48,7 @@ setup(
         'Intended Audience :: Developers',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
+        'Programming Language :: Python :: 3',
         'Framework :: Django',
         'License :: OSI Approved :: BSD License',
     ],

--- a/tests/app/settings.py
+++ b/tests/app/settings.py
@@ -1,8 +1,6 @@
 import os
 import sys
 
-import wagtail.wagtailcore
-
 
 def env(name, default=None):
     if sys.version_info < (3,):
@@ -33,9 +31,7 @@ INSTALLED_APPS = [
     'django.contrib.staticfiles',
 ]
 
-wagtail_version = tuple(map(int, wagtail.wagtailcore.__version__.split('.')))
-if wagtail_version < (1, 4):
-    INSTALLED_APPS += ['compressor']
+ALLOWED_HOSTS = ['localhost']
 
 SECRET_KEY = 'not a secret'
 

--- a/tests/test_deprecation.py
+++ b/tests/test_deprecation.py
@@ -1,0 +1,38 @@
+import json
+import warnings
+
+from django.test import TestCase
+from django.utils import six
+
+from wagtailnews.deprecation import DeprecatedCallableStr
+
+
+class TestDeprecatedCallableStr(TestCase):
+    def test_strness(self):
+        s = DeprecatedCallableStr('foo', warning='nope', warning_cls=DeprecationWarning)
+        self.assertEqual(s, 'foo')
+        self.assertEqual(s + 'bar', 'foobar')
+        self.assertEqual('bar' + s, 'barfoo')
+        self.assertEqual(hash(s), hash('foo'))
+        self.assertEqual(json.dumps(s), '"foo"')
+        self.assertTrue(isinstance(s, str))
+        self.assertTrue(isinstance(s, six.string_types))
+
+    def test_deprecation(self):
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter('always')
+
+            # Creating one should not trigger a deprecation warning
+            s = DeprecatedCallableStr('foo', warning='nope', warning_cls=DeprecationWarning)
+            self.assertEqual(len(w), 0)
+
+            # Doing stringy things should not trigger the warning
+            out = s + 'bar'
+            self.assertEqual(out, 'foobar')
+            self.assertEqual(len(w), 0)
+
+            # Calling the string should trigger the warning
+            out = s()
+            self.assertEqual(out, 'foo')
+            self.assertEqual(len(w), 1)
+            self.assertEqual(w[0].category, DeprecationWarning)

--- a/tests/test_urls.py
+++ b/tests/test_urls.py
@@ -1,7 +1,7 @@
 import datetime
 
 from django.core.cache import cache
-from django.test import TestCase
+from django.test import TestCase, override_settings
 from django.utils import timezone
 from wagtail.tests.utils import WagtailTestUtils
 from wagtail.wagtailcore.models import Page, Site
@@ -118,6 +118,7 @@ class TestNewsList(TestCase, WagtailTestUtils):
             [item], transform=noop)
 
 
+@override_settings(ALLOWED_HOSTS=['localhost', 'site-a.com', 'site-b.org'])
 class TestMultipleSites(TestCase, WagtailTestUtils):
 
     def setUp(self):

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 skip_missing_interpreters = True
 
 envlist =
-	py{34,35}-dj{19,110}-wt{18,19}
+	py{34,35}-dj{110,111}-wt{19,110}
 	isort,flake8,docs
 
 
@@ -22,6 +22,8 @@ deps =
 	wt17: Wagtail~=1.7.0
 	wt18: Wagtail~=1.8.0
 	wt19: Wagtail~=1.9.0
+	wt110: Wagtail~=1.10rc1
+	wt111: Wagtail~=1.11rc1
 
 [testenv:isort]
 usedevelop = True

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 skip_missing_interpreters = True
 
 envlist =
-	py{27,34,35}-dj{19,110}-wt{18,19}
+	py{34,35}-dj{19,110}-wt{18,19}
 	isort,flake8,docs
 
 

--- a/wagtailnews/blocks.py
+++ b/wagtailnews/blocks.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 from django.utils.functional import cached_property
 from wagtail.wagtailcore.blocks import ChooserBlock
 from wagtail.wagtailcore.utils import resolve_model_string

--- a/wagtailnews/deprecation.py
+++ b/wagtailnews/deprecation.py
@@ -1,0 +1,19 @@
+import warnings
+
+
+class DeprecatedCallableStr(str):
+    do_no_call_in_templates = True
+
+    def __new__(cls, value, *args, **kwargs):
+        return super(DeprecatedCallableStr, cls).__new__(cls, value)
+
+    def __init__(self, value, warning, warning_cls):
+        self.warning, self.warning_cls = warning, warning_cls
+
+    def __call__(self, *args, **kwargs):
+        warnings.warn(self.warning, self.warning_cls, stacklevel=2)
+        return str(self)
+
+    def __repr__(self):
+        super_repr = super(DeprecatedCallableStr, self).__repr__()
+        return '<DeprecatedCallableStr {}>'.format(super_repr)

--- a/wagtailnews/feeds.py
+++ b/wagtailnews/feeds.py
@@ -12,10 +12,10 @@ class LatestEntriesFeed(Feed):
         return newsitem_list
 
     def item_link(self, item):
-        return item.full_url()
+        return item.full_url
 
     def item_guid(self, item):
-        return item.full_url()
+        return item.full_url
 
     item_guid_is_permalink = True
 

--- a/wagtailnews/models.py
+++ b/wagtailnews/models.py
@@ -133,7 +133,9 @@ class NewsIndexMixin(RoutablePageMixin):
 
 class AbstractNewsItemRevision(models.Model):
     created_at = models.DateTimeField(verbose_name=_('Created at'))
-    user = models.ForeignKey(settings.AUTH_USER_MODEL, verbose_name=_('User'), null=True, blank=True)
+    user = models.ForeignKey(
+        settings.AUTH_USER_MODEL, verbose_name=_('User'),
+        null=True, blank=True, on_delete=models.SET_NULL)
     content_json = models.TextField(verbose_name=_('Content JSON'))
 
     objects = models.Manager()
@@ -192,7 +194,7 @@ class NewsItemQuerySet(models.QuerySet):
 
 class AbstractNewsItem(index.Indexed, ClusterableModel):
 
-    newsindex = models.ForeignKey(Page)
+    newsindex = models.ForeignKey(Page, on_delete=models.CASCADE)
     date = models.DateTimeField('Published date', default=timezone.now)
 
     live = models.BooleanField(
@@ -220,7 +222,8 @@ class AbstractNewsItem(index.Indexed, ClusterableModel):
     def get_nice_url(self):
         warnings.warn(
             'AbstractNewsItem.get_nice_url() has been renamed to AbstractNewsItem.get_slug()',
-            DeprecationWarning)
+            DeprecationWarning,
+            stacklevel=2)
         return self.get_slug()
 
     def get_slug(self):

--- a/wagtailnews/models.py
+++ b/wagtailnews/models.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 import datetime
 import os
 import warnings
@@ -11,7 +9,6 @@ from django.shortcuts import get_object_or_404, redirect
 from django.template.response import TemplateResponse
 from django.utils import timezone
 from django.utils.http import urlquote
-from django.utils.six import text_type
 from django.utils.six.moves.urllib.parse import urlparse
 from django.utils.text import slugify
 from django.utils.translation import ugettext_lazy as _
@@ -227,7 +224,7 @@ class AbstractNewsItem(index.Indexed, ClusterableModel):
 
     def get_slug(self):
         allow_unicode = getattr(settings, 'WAGTAIL_ALLOW_UNICODE_SLUGS', True)
-        return slugify(text_type(self), allow_unicode=allow_unicode)
+        return slugify(str(self), allow_unicode=allow_unicode)
 
     def get_template(self, request):
         try:

--- a/wagtailnews/templatetags/wagtailnews_admin_tags.py
+++ b/wagtailnews/templatetags/wagtailnews_admin_tags.py
@@ -12,7 +12,7 @@ def newsitem_status(newsitem, link=True):
     output = []
     if newsitem.live:
         buttons.append({
-            'href': newsitem.url(),
+            'href': newsitem.url,
             'primary': True,
             'text': _('live'),
         })

--- a/wagtailnews/urls.py
+++ b/wagtailnews/urls.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 from django.conf.urls import url
 
 from .views import chooser, editor

--- a/wagtailnews/views/chooser.py
+++ b/wagtailnews/views/chooser.py
@@ -7,7 +7,6 @@ from django.core.exceptions import PermissionDenied
 from django.core.urlresolvers import reverse
 from django.http import Http404
 from django.shortcuts import get_object_or_404, redirect, render
-from django.utils.six import text_type
 from wagtail.utils.pagination import paginate
 from wagtail.wagtailadmin.forms import SearchForm
 from wagtail.wagtailadmin.modal_workflow import render_modal_workflow
@@ -191,7 +190,7 @@ def chosen_modal(request, pk, newsitem_pk):
     return render_modal_workflow(request, None, 'wagtailnews/chooser/chosen.js', {
         'newsitem_json': json.dumps({
             'id': newsitem.id,
-            'string': text_type(newsitem),
+            'string': str(newsitem),
             'edit_link': reverse('wagtailnews:edit', kwargs={
                 'pk': newsindex.pk, 'newsitem_pk': newsitem.pk}),
         }),

--- a/wagtailnews/views/editor.py
+++ b/wagtailnews/views/editor.py
@@ -1,3 +1,6 @@
+from io import StringIO
+from urllib.parse import urlparse
+
 from django.conf import settings
 from django.core.exceptions import PermissionDenied
 from django.core.handlers.base import BaseHandler
@@ -5,8 +8,6 @@ from django.core.handlers.wsgi import WSGIRequest
 from django.core.urlresolvers import reverse
 from django.shortcuts import get_object_or_404, redirect, render
 from django.utils.lru_cache import lru_cache
-from django.utils.six import StringIO
-from django.utils.six.moves.urllib.parse import urlparse
 from django.utils.translation import ugettext_lazy as _
 from wagtail.wagtailadmin import messages
 from wagtail.wagtailadmin.edit_handlers import (

--- a/wagtailnews/views/editor.py
+++ b/wagtailnews/views/editor.py
@@ -196,7 +196,7 @@ def view_draft(request, pk, newsitem_pk):
     template = newsitem.get_template(dummy_request)
     context = newsitem.get_context(
         dummy_request, year=newsitem.date.year, month=newsitem.date.month,
-        day=newsitem.date.day, pk=newsitem.pk, slug=newsitem.get_nice_url())
+        day=newsitem.date.day, pk=newsitem.pk, slug=newsitem.get_slug())
     return render(dummy_request, template, context)
 
 

--- a/wagtailnews/views/editor.py
+++ b/wagtailnews/views/editor.py
@@ -208,7 +208,7 @@ def build_dummy_request(newsitem):
     display a view of this page in the admin interface without going
     through the regular page routing logic.
     """
-    url = newsitem.full_url()
+    url = newsitem.full_url
     if url:
         url_info = urlparse(url)
         hostname = url_info.hostname

--- a/wagtailnews/wagtail_hooks.py
+++ b/wagtailnews/wagtail_hooks.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 from django.conf.urls import include, url
 from django.contrib.auth.models import Permission
 from django.contrib.contenttypes.models import ContentType

--- a/wagtailnews/widgets.py
+++ b/wagtailnews/widgets.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 import json
 
 from django.template.loader import render_to_string


### PR DESCRIPTION
This keeps it consistent with Page.url being a property. Backwards compatibility has been kept by making NewsItem.url a callable string that returns itself, while also raising a DeprecationWarning.

Builds on top of #6 and #8 