### PR TITLE
Add signals and update relevant tests to account for them

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -15,6 +15,7 @@ Contents:
    usage
    forms
    rss
+   signals
    reference
 
 

--- a/docs/signals.rst
+++ b/docs/signals.rst
@@ -1,0 +1,71 @@
+.. _signals:
+
+=======
+Signals
+=======
+
+Because news items are not wagtail pages, they can not react to wagtail hooks or
+signals.  ``wagtailnews`` provides a set of ``django.dispatch`` signals for
+easier extension and customizability.
+
+.. code-block:: python
+
+  from wagtailnews.signals import newsitem_published
+  from django.dispatch import receiver
+
+  @receiver(newsitem_published)
+  def callback(sender, **kwargs):
+      print('News item published!')
+
+As with every other django signal, the ``sender`` and ``signal`` kwargs are
+always included.
+
+.. _newsitem_published:
+
+``newsitem_published``
+______________________
+
+A signal sent out when a news item is published, with the following kwargs:
+
+instance
+    The newsitem that was just created
+created
+    Whether this publishing created the newsitem (This does not indicate that the newsitem was
+    published for the first time, but that it was just created as a new database
+    record.  This will only be set once across :ref:`newsitem_draft_saved` and
+    this signal, depending which action is done first)
+
+.. _newsitem_draft_saved:
+
+``newsitem_draft_saved``
+________________________
+
+A signal sent out when a news item had a draft saved, with the following kwargs:
+
+instance
+    The newsitem that was just created
+created
+    Whether this publishing created the newsitem (see :ref:`newsitem_published`
+    for some more information)
+
+.. _newsitem_unpublished:
+
+``newsitem_unpublished``
+________________________
+
+A signal sent out when a news item is unpublished, with the following kwargs:
+
+instance
+    The newsitem that was just created
+
+.. _newsitem_deleted:
+
+``newsitem_deleted``
+____________________
+
+A signal sent out when a news item is deleted, with the following kwargs:
+
+instance
+    The newsitem that was just created.  Be careful, this is the instance as-is
+    after it has been deleted from the database, just like django's native
+    ``post_delete`` signal.

--- a/wagtailnews/signals.py
+++ b/wagtailnews/signals.py
@@ -1,0 +1,6 @@
+from django.dispatch import Signal
+
+newsitem_published = Signal(providing_args=['instance', 'created'])
+newsitem_unpublished = Signal(providing_args=['instance'])
+newsitem_draft_saved = Signal(providing_args=['instance', 'created'])
+newsitem_deleted = Signal(providing_args=['instance'])

--- a/wagtailnews/views/editor.py
+++ b/wagtailnews/views/editor.py
@@ -14,6 +14,7 @@ from wagtail.wagtailadmin.edit_handlers import (
     ObjectList, extract_panel_definitions_from_model_class)
 from wagtail.wagtailcore.models import Page
 
+from .. import signals
 from ..forms import SaveActionSet
 from ..models import NewsIndexMixin
 from ..permissions import format_perms, perms_for_template
@@ -56,10 +57,12 @@ def create(request, pk):
 
             if action is SaveActionSet.publish:
                 messages.success(request, _('The news post "{0!s}" has been published').format(newsitem))
+                signals.newsitem_published.send(sender=NewsItem, instance=newsitem, created=True)
                 return redirect('wagtailnews:index', pk=newsindex.pk)
 
             elif action is SaveActionSet.draft:
                 messages.success(request, _('A draft news post "{0!s}" has been created').format(newsitem))
+                signals.newsitem_draft_saved.send(sender=NewsItem, instance=newsitem, created=True)
                 return redirect('wagtailnews:edit', pk=newsindex.pk, newsitem_pk=newsitem.pk)
 
             elif action is SaveActionSet.preview:
@@ -111,10 +114,12 @@ def edit(request, pk, newsitem_pk):
             if action is SaveActionSet.publish:
                 revision.publish()
                 messages.success(request, _('Your changes to "{0!s}" have been published').format(newsitem))
+                signals.newsitem_published.send(sender=NewsItem, instance=newsitem, created=False)
                 return redirect('wagtailnews:index', pk=newsindex.pk)
 
             elif action is SaveActionSet.draft:
                 messages.success(request, _('Your changes to "{0!s}" have been saved as a draft').format(newsitem))
+                signals.newsitem_draft_saved.send(sender=NewsItem, instance=newsitem, created=False)
                 return redirect('wagtailnews:edit', pk=newsindex.pk, newsitem_pk=newsitem.pk)
 
             elif action is SaveActionSet.preview:
@@ -155,6 +160,7 @@ def unpublish(request, pk, newsitem_pk):
         messages.success(request, _('{} has been unpublished').format(newsitem), [
             (reverse('wagtailnews:edit', kwargs={'pk': pk, 'newsitem_pk': newsitem_pk}), _('Edit')),
         ])
+        signals.newsitem_unpublished.send(sender=NewsItem, instance=newsitem)
         return redirect('wagtailnews:index', pk=pk)
 
     return render(request, 'wagtailnews/unpublish.html', {
@@ -176,6 +182,7 @@ def delete(request, pk, newsitem_pk):
 
     if request.method == 'POST':
         newsitem.delete()
+        signals.newsitem_deleted.send(sender=NewsItem, instance=newsitem)
         return redirect('wagtailnews:index', pk=pk)
 
     return render(request, 'wagtailnews/delete.html', {


### PR DESCRIPTION
Adds signals to the most common changes for newsitems, as newsitems aren't wagtail pages and can't react to wagtail page signals or most hooks.
closes #9